### PR TITLE
feat(product): validate remains before decrement

### DIFF
--- a/src/product/product.service.spec.ts
+++ b/src/product/product.service.spec.ts
@@ -1,0 +1,47 @@
+import { BadRequestException } from '@nestjs/common'
+jest.mock('./product.model', () => ({}), { virtual: true })
+jest.mock('../category/category.model', () => ({}), { virtual: true })
+jest.mock('@nestjs/sequelize', () => ({
+	InjectModel: () => () => {},
+	InjectConnection: () => () => {}
+}))
+import { ProductService } from './product.service'
+
+describe('ProductService.decreaseRemains', () => {
+	let service: ProductService
+	let productRepo: { decrement: jest.Mock }
+	let sequelize: { transaction: jest.Mock }
+
+	beforeEach(() => {
+		productRepo = { decrement: jest.fn() } as any
+		sequelize = { transaction: jest.fn() } as any
+		service = new ProductService(
+			productRepo as any,
+			{} as any,
+			sequelize as any
+		)
+	})
+
+	it('throws when remains are insufficient', async () => {
+		jest
+			.spyOn(service, 'findOne')
+			.mockResolvedValue({ id: 1, remains: 1 } as any)
+		const trx = {} as any
+		await expect(service.decreaseRemains(1, 5, trx)).rejects.toThrow(
+			BadRequestException
+		)
+		expect(productRepo.decrement).not.toHaveBeenCalled()
+	})
+
+	it('decrements when enough remains', async () => {
+		jest
+			.spyOn(service, 'findOne')
+			.mockResolvedValue({ id: 1, remains: 10 } as any)
+		const trx = {} as any
+		await service.decreaseRemains(1, 5, trx)
+		expect(productRepo.decrement).toHaveBeenCalledWith(
+			{ remains: 5 },
+			{ where: { id: 1 }, transaction: trx }
+		)
+	})
+})

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -139,6 +139,10 @@ export class ProductService {
 		trx?: Transaction
 	): Promise<void> {
 		const operation = async (t: Transaction) => {
+			const product = await this.findOne(productId, t)
+			if (product.remains < qty) {
+				throw new BadRequestException('Недостаточно остатков')
+			}
 			await this.productRepo.decrement(
 				{ remains: qty },
 				{ where: { id: productId }, transaction: t }


### PR DESCRIPTION
## Summary
- safeguard product stock decrements by loading current remains and throwing when insufficient
- add unit tests for decreaseRemains covering insufficient and sufficient stock scenarios

## Testing
- `npm test`
- `npm run lint` *(fails: Key "@typescript-eslint/no-extraneous-class" allowEmptyCase option)*

------
https://chatgpt.com/codex/tasks/task_e_689376ae64388329ac545dcc6e283227