### PR TITLE
feat: add task CRUD with executor field

### DIFF
--- a/src/task/dto/task.dto.ts
+++ b/src/task/dto/task.dto.ts
@@ -1,0 +1,29 @@
+import {
+        IsDateString,
+        IsEnum,
+        IsNotEmpty,
+        IsOptional,
+        IsString
+} from 'class-validator'
+import { TaskStatus } from '../task.model'
+
+export class CreateTaskDto {
+        @IsString()
+        @IsNotEmpty()
+        title: string
+
+        @IsString()
+        @IsOptional()
+        description?: string
+
+        @IsDateString()
+        deadline: string
+
+        @IsEnum(TaskStatus)
+        @IsOptional()
+        status?: TaskStatus
+
+        @IsString()
+        @IsOptional()
+        executor?: string
+}

--- a/src/task/dto/update.task.dto.ts
+++ b/src/task/dto/update.task.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types'
+import { CreateTaskDto } from './task.dto'
+
+export class UpdateTaskDto extends PartialType(CreateTaskDto) {}

--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -1,7 +1,49 @@
-import { Controller } from '@nestjs/common';
-import { TaskService } from './task.service';
+import {
+        Body,
+        Controller,
+        Delete,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        Put
+} from '@nestjs/common'
+import { TaskService } from './task.service'
+import { TaskModel } from './task.model'
+import { CreateTaskDto } from './dto/task.dto'
+import { UpdateTaskDto } from './dto/update.task.dto'
 
 @Controller('task')
 export class TaskController {
-  constructor(private readonly taskService: TaskService) {}
+        constructor(private readonly taskService: TaskService) {}
+
+        @Post()
+        async create(@Body() dto: CreateTaskDto): Promise<TaskModel> {
+                return this.taskService.create(dto)
+        }
+
+        @Get()
+        async findAll(): Promise<TaskModel[]> {
+                return this.taskService.findAll()
+        }
+
+        @Get(':id')
+        async findOne(
+                @Param('id', ParseIntPipe) id: number
+        ): Promise<TaskModel> {
+                return this.taskService.findOne(id)
+        }
+
+        @Put(':id')
+        async update(
+                @Param('id', ParseIntPipe) id: number,
+                @Body() dto: UpdateTaskDto
+        ): Promise<TaskModel> {
+                return this.taskService.update(id, dto)
+        }
+
+        @Delete(':id')
+        async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+                return this.taskService.remove(id)
+        }
 }

--- a/src/task/task.model.ts
+++ b/src/task/task.model.ts
@@ -10,7 +10,10 @@ export enum TaskStatus {
 	tableName: 'Task',
 	deletedAt: false,
 	version: false,
-	indexes: [{ fields: ['deadline'] }, { fields: ['status'] }]
+        indexes: [
+                { fields: ['deadline'] },
+                { fields: ['status'] }
+        ]
 })
 export class TaskModel extends Model {
 	@Column(DataType.TEXT)
@@ -22,9 +25,12 @@ export class TaskModel extends Model {
 	@Column(DataType.DATE)
 	deadline: Date // Дедлайн задачи
 
-	@Column({
-		type: DataType.ENUM(...Object.values(TaskStatus)),
-		defaultValue: TaskStatus.Pending
-	})
-	status: TaskStatus // Статус задачи
+        @Column({
+                type: DataType.ENUM(...Object.values(TaskStatus)),
+                defaultValue: TaskStatus.Pending
+        })
+        status: TaskStatus // Статус задачи
+
+        @Column(DataType.STRING)
+        executor?: string // Исполнитель задачи
 }

--- a/src/task/task.module.ts
+++ b/src/task/task.module.ts
@@ -5,7 +5,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 import { TaskModel } from './task.model'
 
 @Module({
-	imports: [SequelizeModule.forFeature([TaskModel])],
+        imports: [SequelizeModule.forFeature([TaskModel])],
 	controllers: [TaskController],
 	providers: [TaskService]
 })

--- a/src/task/task.service.ts
+++ b/src/task/task.service.ts
@@ -1,4 +1,36 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { TaskModel } from './task.model'
+import { CreateTaskDto } from './dto/task.dto'
+import { UpdateTaskDto } from './dto/update.task.dto'
 
 @Injectable()
-export class TaskService {}
+export class TaskService {
+        constructor(@InjectModel(TaskModel) private readonly taskRepo: typeof TaskModel) {}
+
+        async create(dto: CreateTaskDto): Promise<TaskModel> {
+                return this.taskRepo.create({ ...dto })
+        }
+
+        async findAll(): Promise<TaskModel[]> {
+                return this.taskRepo.findAll()
+        }
+
+        async findOne(id: number): Promise<TaskModel> {
+                const task = await this.taskRepo.findByPk(id)
+                if (!task) {
+                        throw new NotFoundException(`Task #${id} не найдена`)
+                }
+                return task
+        }
+
+        async update(id: number, dto: UpdateTaskDto): Promise<TaskModel> {
+                const task = await this.findOne(id)
+                return task.update(dto)
+        }
+
+        async remove(id: number): Promise<void> {
+                const task = await this.findOne(id)
+                await task.destroy()
+        }
+}


### PR DESCRIPTION
## Summary
- remove user associations from tasks and add executor string field
- adjust DTOs, service and module to operate without users

## Testing
- `npm test`
- `npm run lint` *(fails: Key "@typescript-eslint/no-extraneous-class": Value {"allowEmptyCase":true,"allowStaticOnly":false,"allowWithDecorator":true} should NOT have additional properties.)*

------
https://chatgpt.com/codex/tasks/task_e_689376a6e22c83298ef0125e5fdc5c41