### PR TITLE
fix: use transaction when fetching product price

### DIFF
--- a/src/sale/sale.service.ts
+++ b/src/sale/sale.service.ts
@@ -32,9 +32,12 @@ export class SaleService {
 				trx
 			)
 
-			// 2) Получаем цену продажи для расчёта totalPrice
-			const product = await this.productService.findOne(dto.productId)
-			const totalPrice = product.salePrice * dto.quantitySold
+                        // 2) Получаем цену продажи для расчёта totalPrice в контексте trx
+                        const product = await this.productService.findOne(
+                                dto.productId,
+                                trx
+                        )
+                        const totalPrice = product.salePrice * dto.quantitySold
 
 			// 3) Создаём запись о продаже
 			const sale = await this.saleRepo.create(


### PR DESCRIPTION
## Summary
- ensure product lookup during sale creation occurs within the same transaction

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected property "allowEmptyCase")*


------
https://chatgpt.com/codex/tasks/task_e_6893781cbb048329b87f9c77afff6ac1