### PR TITLE
feat: add analytics module

### DIFF
--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Query } from '@nestjs/common'
+import { AnalyticsService } from './analytics.service'
+import { ProductModel } from '../product/product.model'
+
+function parseCategories(value?: string): number[] | undefined {
+	if (!value) return undefined
+	return value
+		.split(',')
+		.map((id) => parseInt(id, 10))
+		.filter((n) => !isNaN(n))
+}
+
+@Controller('analytics')
+export class AnalyticsController {
+	constructor(private readonly analyticsService: AnalyticsService) {}
+
+	@Get('revenue')
+	getRevenue(
+		@Query('startDate') startDate?: string,
+		@Query('endDate') endDate?: string,
+		@Query('categories') categories?: string
+	): Promise<number> {
+		const ids = parseCategories(categories)
+		return this.analyticsService.getRevenue(startDate, endDate, ids)
+	}
+
+	@Get('category-sales')
+	getCategorySales(
+		@Query('startDate') startDate?: string,
+		@Query('endDate') endDate?: string,
+		@Query('categories') categories?: string
+	): Promise<any[]> {
+		const ids = parseCategories(categories)
+		return this.analyticsService.getSalesByCategories(startDate, endDate, ids)
+	}
+
+	@Get('low-stock')
+	getLowStock(
+		@Query('threshold') threshold = '10',
+		@Query('categories') categories?: string
+	): Promise<ProductModel[]> {
+		const ids = parseCategories(categories)
+		const thr = parseInt(threshold, 10)
+		return this.analyticsService.getLowStockProducts(thr, ids)
+	}
+}

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { AnalyticsService } from './analytics.service'
+import { AnalyticsController } from './analytics.controller'
+import { SaleModel } from '../sale/sale.model'
+import { ProductModel } from '../product/product.model'
+import { CategoryModel } from '../category/category.model'
+
+@Module({
+	imports: [
+		SequelizeModule.forFeature([SaleModel, ProductModel, CategoryModel])
+	],
+	controllers: [AnalyticsController],
+	providers: [AnalyticsService]
+})
+export class AnalyticsModule {}

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { Op, fn, col } from 'sequelize'
+import { SaleModel } from '../sale/sale.model'
+import { ProductModel } from '../product/product.model'
+import { CategoryModel } from '../category/category.model'
+
+@Injectable()
+export class AnalyticsService {
+	constructor(
+		@InjectModel(SaleModel)
+		private readonly saleRepo: typeof SaleModel,
+		@InjectModel(ProductModel)
+		private readonly productRepo: typeof ProductModel
+	) {}
+
+	async getRevenue(
+		startDate?: string,
+		endDate?: string,
+		categoryIds?: number[]
+	): Promise<number> {
+		const where: any = {}
+		if (startDate || endDate) {
+			if (startDate && endDate) {
+				where.saleDate = { [Op.between]: [startDate, endDate] }
+			} else if (startDate) {
+				where.saleDate = { [Op.gte]: startDate }
+			} else if (endDate) {
+				where.saleDate = { [Op.lte]: endDate }
+			}
+		}
+		if (categoryIds && categoryIds.length) {
+			where['$product.category_id$'] = { [Op.in]: categoryIds }
+		}
+		const revenue = await this.saleRepo.sum('totalPrice', {
+			where,
+			include:
+				categoryIds && categoryIds.length
+					? [{ model: ProductModel, attributes: [] }]
+					: undefined
+		})
+		return parseFloat(String(revenue)) || 0
+	}
+
+	async getSalesByCategories(
+		startDate?: string,
+		endDate?: string,
+		categoryIds?: number[]
+	): Promise<any[]> {
+		const whereSales: any = {}
+		if (startDate || endDate) {
+			if (startDate && endDate) {
+				whereSales.saleDate = { [Op.between]: [startDate, endDate] }
+			} else if (startDate) {
+				whereSales.saleDate = { [Op.gte]: startDate }
+			} else if (endDate) {
+				whereSales.saleDate = { [Op.lte]: endDate }
+			}
+		}
+
+		const includeProduct: any = {
+			model: ProductModel,
+			attributes: [],
+			include: [{ model: CategoryModel, attributes: [] }]
+		}
+		if (categoryIds && categoryIds.length) {
+			includeProduct.where = { categoryId: { [Op.in]: categoryIds } }
+		}
+
+		const rows = await this.saleRepo.findAll({
+			attributes: [
+				[col('product->category.id'), 'categoryId'],
+				[col('product->category.name'), 'categoryName'],
+				[fn('SUM', col('quantity_sold')), 'totalUnits'],
+				[fn('SUM', col('total_price')), 'totalRevenue']
+			],
+			where: whereSales,
+			include: [includeProduct],
+			group: [
+				'product.category_id',
+				'product->category.id',
+				'product->category.name'
+			],
+			raw: true
+		})
+		return rows
+	}
+
+	async getLowStockProducts(
+		threshold = 10,
+		categoryIds?: number[]
+	): Promise<ProductModel[]> {
+		const where: any = { remains: { [Op.lte]: threshold } }
+		if (categoryIds && categoryIds.length) {
+			where.categoryId = { [Op.in]: categoryIds }
+		}
+		return this.productRepo.findAll({ where, include: ['category'] })
+	}
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ProductModule } from './product/product.module'
 import { SaleModule } from './sale/sale.module'
 import { TaskModule } from './task/task.module'
 import { CategoryModule } from './category/category.module'
+import { AnalyticsModule } from './analytics/analytics.module'
 
 @Module({
 	imports: [
@@ -26,7 +27,8 @@ import { CategoryModule } from './category/category.module'
 		ProductModule,
 		SaleModule,
 		TaskModule,
-		CategoryModule
+		CategoryModule,
+		AnalyticsModule
 	],
 	controllers: [AppController],
 	providers: [AppService]


### PR DESCRIPTION
## Summary
- add analytics module aggregating sales and products data
- expose endpoints for revenue, category sales and low stock products
- wire analytics module into application

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected property "allowEmptyCase" in ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6893787e97e88329a98b927cdf640083