### PR TITLE
refactor: rename category controller route

### DIFF
--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -13,7 +13,7 @@ import { CategoryModel } from './category.model'
 import { CreateCategoryDto } from './dto/category.dto'
 import { UpdateCategoryDto } from './dto/update.category.dto'
 
-@Controller('category')
+@Controller('categories')
 export class CategoryController {
 	constructor(private readonly categoryService: CategoryService) {}
 


### PR DESCRIPTION
## Summary
- use plural base path for categories controller

## Testing
- `npm test`
- `npm run test:e2e` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `npm run lint` *(fails: Unexpected property "allowEmptyCase" in @typescript-eslint/no-extraneous-class)*

------
https://chatgpt.com/codex/tasks/task_e_689388673f9c8329a48bcdcee6070a34